### PR TITLE
Fix mobile job header overlay bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -446,6 +446,11 @@
                 grid-template-columns: 1fr; 
                 gap: 30px;
             }
+            /* Disable sticky meta on mobile to prevent overlap with content */
+            .experience-meta {
+                position: static;
+                top: auto;
+            }
             .portfolio-grid { 
                 grid-template-columns: 1fr; 
             }


### PR DESCRIPTION
Disable sticky positioning for `.experience-meta` on mobile to prevent text overlap during scrolling.

On mobile, the layout collapses to a single column, but the `.experience-meta` element (containing dates and job titles) retained its `position: sticky` property, causing it to overlay the main content text when scrolling. This change applies `position: static` specifically within the mobile media query to resolve the overlap.

---
<a href="https://cursor.com/background-agent?bcId=bc-bb6147ff-6fc7-4ecf-a276-14893ae602f5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bb6147ff-6fc7-4ecf-a276-14893ae602f5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

